### PR TITLE
add applyRouterMiddleware (#21)

### DIFF
--- a/modules/applyRouterMiddleware.js
+++ b/modules/applyRouterMiddleware.js
@@ -1,0 +1,36 @@
+/**
+ * This file is subject to the terms and conditions defined in the LICENSE file
+ * which is found in the in the root directory of React Router source tree.
+ *
+ * https://github.com/reactjs/react-router/blob/master/LICENSE.md
+ */
+
+import React, { createElement } from 'react';
+import RouterContext from './RouterContext';
+
+export default (...middlewares) => {
+  const withContext = middlewares.map(m => m.renderRouterContext).filter(f => f);
+  const withComponent = middlewares.map(m => m.renderRouteComponent).filter(f => f);
+  const makeCreateElement = (baseCreateElement = createElement) => (
+    (Component, props) => (
+      withComponent.reduceRight(
+        (previous, renderRouteComponent) => (
+          renderRouteComponent(previous, props)
+        ), baseCreateElement(Component, props)
+      )
+    )
+  );
+
+  return (renderProps) => (
+    withContext.reduceRight(
+      (previous, renderRouterContext) => (
+        renderRouterContext(previous, renderProps)
+      ), (
+      <RouterContext
+        {...renderProps}
+        createElement={makeCreateElement(renderProps.createElement)}
+      />
+      )
+    )
+  );
+};


### PR DESCRIPTION
As discussed in #21.

Ideally and for maximum code reusability we would want to submit a patch to upstream to make this work with any `RouterContext`:

``` js
export const createApplyRouterMiddleware = (context) => (...middlewares) => {};

export default createApplyRouterMiddleware(RouterContext);
```

🍺 
