### PR TITLE
Changes navigationCard bg color to 'transparent'.

### DIFF
--- a/modules/styles.js
+++ b/modules/styles.js
@@ -17,7 +17,7 @@ const globalStyles = StyleSheet.create({
   },
   navigationCard: {
     ...absoluteFillObject,
-    backgroundColor: '#E9E9EF',
+    backgroundColor: 'transparent',
     overflow: 'hidden',
   },
 });


### PR DESCRIPTION
- `npm run lint` passes
- `npm run spec` passes
- Was unable to `npm test` in master or this branch (flow failures).
- Was unable to run the Aviato app in master or this branch. (see screenshot)

![screenshot 2016-07-12 12 20 36](https://cloud.githubusercontent.com/assets/319152/16780568/0672d4ec-482c-11e6-87e9-58570b89d9e7.png)
