### PR TITLE
fix styles.wrapper to be compatible with RN 0.32 NavExp layout change

### DIFF
--- a/modules/styles.js
+++ b/modules/styles.js
@@ -14,6 +14,7 @@ const { absoluteFillObject } = StyleSheet;
 const globalStyles = StyleSheet.create({
   wrapper: {
     flex: 1,
+    flexDirection: 'column-reverse',
   },
   navigationCard: {
     ...absoluteFillObject,


### PR DESCRIPTION
As discussed in #36.

See https://github.com/facebook/react-native/commit/38979f9c68bd054aca3c6102635b2005914506b1
