### PR TITLE
Add transitionRegistry to index exports

### DIFF
--- a/modules/index.js
+++ b/modules/index.js
@@ -25,6 +25,7 @@ import {
 import { render } from './render';
 import Reducer from './Reducer';
 import RouterContext from './RouterContext';
+import transitionRegistry from './transitionRegistry';
 
 /* histories */
 import nativeHistory from './nativeHistory';
@@ -47,4 +48,5 @@ export {
   render,
   RouterContext,
   nativeHistory,
+  transitionRegistry,
 };


### PR DESCRIPTION
I figured this should be public api, since the user can use it to add custom transitions. 
