### PR TITLE
Fix invariant for route definition correctness

### DIFF
--- a/modules/ReducerUtils.js
+++ b/modules/ReducerUtils.js
@@ -331,7 +331,7 @@ export function createPartialState(
     }
 
     invariant(
-      key && path && type && reducer && (transition || type === ROUTE),
+      key && path && type && (reducer || type === 'index') && (transition || type === ROUTE || type === 'index'),
       'Incompatible route definition. Make sure peer dependecy requirements are met. If you are ' +
       'using plain objects to define your routes, in addition to the options required by React ' +
       'Router, each route has to specify the following: `routeType`, `reducer`, `transition`.'


### PR DESCRIPTION
Not 100% sure that this is correct: the invariant _said_ that IndexRoutes must have a `transition` and a `reducer` defined. I think this is not correct which is why i bypassed these checks for IndexRoutes.
So: maybe fixes #39. Thought?
