### PR TITLE
remove semicolons for consistency

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,11 +6,13 @@ Be it a bug fix, new feature, [documentation](/docs), or tests—we love pull re
 [How to Contribute to an Open Source Project on GitHub](https://egghead.io/series/how-to-contribute-to-an-open-source-project-on-github).
 
 <a name="bug"/>
+
 ## Found a Bug?
 
 Look through the GitHub issues for bugs. Anything tagged with "bug" is open to whoever wants to implement it. If you'd like to report a bug, please provide a reproducible test case. If possible, submit a Pull Request with a failing test.
 
 <a name="pr"/>
+
 ## Making a Pull Request?
 The following guidelines will make your pull request easier to merge. So please, read on.
 
@@ -41,6 +43,7 @@ npm test
 Please be patient when your changes aren't merged immediately.
 
 <a name="hacking"/>
+
 ## Hacking
 
 Unfortunately, React Native packager does not support symlinking so you cannot use [`npm link`](https://docs.npmjs.com/cli/link) when hacking on this library. You can learn more about that, [here](https://productpains.com/post/react-native/symlink-support-for-packager/).
@@ -54,14 +57,17 @@ npm run watch
 This will automatically watch the `modules` directory and sync your changes into `examples/Aviato/node_modules` every time something changes.
 
 <a name="repo-format"/>
+
 ## Flat Repository Format
 This project uses a flat repository structure. All source code is placed directly into `modules` directory. The main reason is that both `history` and `react-router` source repositories follow this convention and hacking on this library means hacking on those two as well. Mirroring the conventions used in those repos should make it easier to connect the pieces together.
 
 <a name="feedback"/>
+
 ## Feedback
 
 Feedback is always welcome. The best way to send feedback is to file an issue. If you are proposing a feature, explain in detail how it would work.
 
 <a name="license"/>
+
 ## License
 All pull requests that get merged will be made available under [the MIT license](https://github.com/jmurzy/react-router-native/blob/master/LICENSE.md), as the rest of the repository.

--- a/docs/README.md
+++ b/docs/README.md
@@ -37,7 +37,7 @@ Redux is supported via [react-router-redux](https://github.com/reactjs/react-rou
 import React from 'react'
 import { createStore, combineReducers, applyMiddleware } from 'redux'
 import { Provider } from 'react-redux'
-import { Router, nativeHistory } from 'react-router-native';
+import { Router, nativeHistory } from 'react-router-native'
 import { syncHistoryWithStore, routerReducer } from 'react-router-redux'
 
 import reducers from '<project-path>/reducers'
@@ -62,7 +62,7 @@ const routes = (
       /* ... */
     </Router>
   </Provider>
-);
+)
 
-AppRegistry.registerComponent('YourApp', () => () => routes);
+AppRegistry.registerComponent('YourApp', () => () => routes)
 ```


### PR DESCRIPTION
The mixing of lines with and without semicolons makes it look like copy/paste code.  This also fixes the markdown on the contributing page so headers render as headers and not `## Foo`.